### PR TITLE
Fix link to Gitcoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 
 [![https://badges.frapsoft.com/os/mit/mit.svg?v=102](https://badges.frapsoft.com/os/mit/mit.svg?v=102)](https://opensource.org/licenses/MIT) [![Build Status](https://travis-ci.org/ProjectWyvern/wyvern-ethereum.svg?branch=master)](https://travis-ci.org/ProjectWyvern/wyvern-ethereum) [![Coverage Status](https://coveralls.io/repos/github/ProjectWyvern/wyvern-ethereum/badge.svg?branch=master)](https://coveralls.io/github/ProjectWyvern/wyvern-ethereum?branch=master)
 
+<div>
 <a href="https://gitcoin.co/explorer/?q=https://github.com/ProjectWyvern/wyvern-ethereum" title=”Push Open Source Forward”>
   <img src='https://gitcoin.co/static/v2/images/promo_buttons/slice_01.png' alt=’Browse Gitcoin Bounties’ width="267px" height="52px"/>
 </a>
+</div>
 
 ### Synopsis
 


### PR DESCRIPTION
Fix the image and link that point to the gitcoin bounties for Project Wyvern, though, given that all the bounties have expired a long ago, it may better to simply remove that part from the readme.